### PR TITLE
Verify DEVKITPRO and DEVKITARM are set.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitARM")
+endif
+
+ifeq ($(strip $(DEVKITARM)),)
+$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
+endif
+
 LIBCONFIG            := libconfig
 LIBCONFIG_VERSION    := $(LIBCONFIG)-1.5
 LIBCONFIG_SRC        := $(LIBCONFIG_VERSION).tar.gz


### PR DESCRIPTION
Ran into the issue that when I ran 'sudo make install' that I had forgot to set env_keep on DEVKITPRO and DEVKITARM, thus both where blank and the lib files where copied to /portlibs/ instead of the correct folder DEVKITPRO and DEVKITARM. This should fix this possible issue for future users.